### PR TITLE
fix(package): move Marked to required dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "@angular/core": "^2.0.0 || ^4.0.0",
     "@types/es6-shim": "^0.0.29",
     "@types/tape": "^4.2.27",
-    "marked": "^0.3.6",
     "reflect-metadata": "^0.1.8",
     "rxjs": "^5.0.0-beta.12",
     "tape": "^4.6.0",
@@ -49,10 +48,10 @@
     "zone.js": "^0.6.14"
   },
   "peerDependencies": {
-    "@angular/core": "^2.0.0 || ^4.0.0",
-    "marked": "^0.3.6"
+    "@angular/core": "^2.0.0 || ^4.0.0"
   },
   "dependencies": {
-    "@types/marked": "^0.0.27"
+    "@types/marked": "^0.0.27",
+    "marked": "^0.3.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -52,6 +52,6 @@
   },
   "dependencies": {
     "@types/marked": "^0.0.27",
-    "marked": "^0.3.6"
+    "marked": "^0.x"
   }
 }


### PR DESCRIPTION
`marked` is necessary to run this project, without it developer will see the following error in console:
```
ERROR in ./~/markdown-to-html-pipe/src/markdown-to-html.pipe.js
Module not found: Error: Can't resolve 'marked' in '/Users/danielkucal/Applications/Angular2/danielkucal.com/node_modules/markdown-to-html-pipe/src'
 @ ./~/markdown-to-html-pipe/src/markdown-to-html.pipe.js 3:13-30
 @ ./~/markdown-to-html-pipe/index.js
 @ ./src/app/app.module.ts
 @ ./src/main.ts
 @ multi webpack-dev-server/client?http://localhost:4200 ./src/main.ts
```