### PR TITLE
allow for inline ouput using additional pipe param

### DIFF
--- a/src/markdown-to-html.pipe.ts
+++ b/src/markdown-to-html.pipe.ts
@@ -6,9 +6,9 @@ import * as marked from 'marked';
 })
 
 export class MarkdownToHtmlPipe implements PipeTransform {
-    public transform(markdown: string, options?: MarkedOptions): string {
+    public transform(markdown: string, options?: MarkedOptions, inline?: boolean): string {
         if (markdown == null) return '';
-        return marked(markdown, options);
+        return (inline) ? marked.inlineLexer(markdown, [], options) : marked(markdown, options);
     }
 
     public static setOptions(options: MarkedOptions): void {


### PR DESCRIPTION
Added an additional arg so the user can use the inlineLexer to prevent the output of the p parameter. I'm new to the world of pipes but figured this might be the best way to do it. 

So an example with the additional argument would be: 
`[innerHTML]="t.text || t.full_text | MarkdownToHtml:{}:true"`

I'm adding this functionality because I am leveraging your functionality in one of my projects and could use it as well. 

